### PR TITLE
update suggested django-debug-toolbar (DDT) integration in settings/local.py

### DIFF
--- a/wagtaildemo/settings/local.py.example
+++ b/wagtaildemo/settings/local.py.example
@@ -12,16 +12,16 @@ SECRET_KEY = 'enter-a-long-unguessable-string-here'
 
 # When developing Wagtail templates, we recommend django-debug-toolbar
 # for keeping track of page rendering times. To use it:
-#     pip install django-debug-toolbar==1.0.1
-# and uncomment the lines below.
+#     pip install django-debug-toolbar
+# uncomment the lines below, and uncomment the corresponding lines in urls.py
 
 # from .base import INSTALLED_APPS, MIDDLEWARE_CLASSES
 # INSTALLED_APPS += (
 #     'debug_toolbar',
 # )
-# MIDDLEWARE_CLASSES += (
+# MIDDLEWARE_CLASSES = [
 #     'debug_toolbar.middleware.DebugToolbarMiddleware',
-# )
+# ] + list(MIDDLEWARE_CLASSES)
 # # django-debug-toolbar settings
 # DEBUG_TOOLBAR_CONFIG = {
 #     'INTERCEPT_REDIRECTS': False,

--- a/wagtaildemo/urls.py
+++ b/wagtaildemo/urls.py
@@ -19,10 +19,6 @@ urlpatterns = [
 
     url(r'search/$', views.search, name='search'),
     url(r'^api/', include(wagtailapi_urls)),
-
-    # For anything not caught by a more specific rule above, hand over to
-    # Wagtail's serving mechanism
-    url(r'', include(wagtail_urls)),
 ]
 
 
@@ -35,3 +31,18 @@ if settings.DEBUG:
     urlpatterns += [
         url(r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'demo/images/favicon.ico'))
     ]
+
+    # Uncomment the lines below to enable django-debug-toolbar (along with the
+    # corresponding lines in settings/local.py):
+    # import debug_toolbar
+
+    # urlpatterns += [
+    #     url(r'^__debug__/', include(debug_toolbar.urls)),
+    # ]
+
+
+# For anything not caught by a more specific rule above, hand over to
+# Wagtail's serving mechanism (must come last)
+urlpatterns += [
+    url(r'', include(wagtail_urls)),
+]


### PR DESCRIPTION
* Don't pin an old version of DDT (if there are compatibility issues, hopefully someone installing DDT will be able to work through those)
* Make sure the DDT middleware is first in the list
* Include (commented out) URLs needed by DDT in `urls.py`
* Make sure Wagtail URL routing comes last, so it doesn't return a 404 for DDT urls