### PR TITLE
Remove extra safe filters from search results

### DIFF
--- a/demo/templates/demo/search_results.html
+++ b/demo/templates/demo/search_results.html
@@ -18,7 +18,7 @@
                 {% for pick in search_picks %}
                     <li>
                         <h4><a href="{% pageurl pick.page %}">{{ pick.page.title }}</a></h4>
-                        <p>{{ pick.description|safe }}</p>
+                        <p>{{ pick.description }}</p>
                     </li>
                 {% endfor %}
             </ul>
@@ -31,7 +31,7 @@
                 <li>
                     <h4><a href="{% pageurl result.specific %}">{{ result.specific }}</a></h4>
                     {% if result.specific.search_description %}
-                        {{ result.specific.search_description|safe }}
+                        {{ result.specific.search_description }}
                     {% endif %}
                 </li>
             {% endfor %}


### PR DESCRIPTION
Spotted as part of #112. A potential stored XSS as well, and the filters are useless functionally.

Edit: that's the last two `safe` usages on this site.